### PR TITLE
Remove "logErrorToMyService" from documentation

### DIFF
--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -29,8 +29,6 @@ class ErrorBoundary extends React.Component {
   componentDidCatch(error, info) {
     // Display fallback UI
     this.setState({ hasError: true });
-    // You can also log the error to an error reporting service
-    logErrorToMyService(error, info);
   }
 
   render() {


### PR DESCRIPTION
I was trying to implement "logErrorToMyService" in componentDidCatch() as it is described in documentation but I got:

 'logErrorToMyService' is not defined  no-undef

Actually in live demo "logErrorToMyService" is not there "https://codepen.io/gaearon/pen/wqvxGa?editors=0010", So I think you need to update tutorial or remove it to avoid confusion.



<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/reactjs.org/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
